### PR TITLE
upgrade jose for subpath module exports

### DIFF
--- a/quick-auth/package.json
+++ b/quick-auth/package.json
@@ -40,7 +40,7 @@
     "vitest": "^1.1.0"
   },
   "dependencies": {
-    "jose": "^5.2.3",
+    "jose": "^5.8.0",
     "zod": "^3.25.1"
   },
   "files": [


### PR DESCRIPTION
using jose@5.2.3 is not compatible with the expected import via subpath module exports; fix #7