### PR TITLE
fix: update jose to ^5.8.0 for subpath module exports compatibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
   quick-auth:
     dependencies:
       jose:
-        specifier: ^5.2.3
+        specifier: ^5.8.0
         version: 5.10.0
       typescript:
         specifier: 5.8.3

--- a/quick-auth/package.json
+++ b/quick-auth/package.json
@@ -40,7 +40,7 @@
     "vitest": "^1.1.0"
   },
   "dependencies": {
-    "jose": "^5.2.3",
+    "jose": "^5.8.0",
     "zod": "^3.25.1"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Updates jose dependency from ^5.2.3 to ^5.8.0 to fix subpath module exports compatibility issue
- Resolves the `ERR_PACKAGE_PATH_NOT_EXPORTED` error when importing from the package

## Problem
The jose library version 5.2.3 does not support subpath module exports like `jose/jwt/decode`, which causes import errors when using @farcaster/quick-auth or @farcaster/miniapp-sdk packages. This has been blocking developers following the getting started documentation for over a month.

## Solution
Update the minimum jose version to 5.8.0, which introduced proper support for subpath module exports.

## Test plan
- [x] All existing tests pass
- [x] Package builds successfully  
- [x] Verified imports work correctly with jose@5.8.0
- [x] Tested that the fix resolves the reported error

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)